### PR TITLE
Deleting user

### DIFF
--- a/__tests__/endpoint_tests/users/delete-user.test.js
+++ b/__tests__/endpoint_tests/users/delete-user.test.js
@@ -1,0 +1,158 @@
+const request = require("supertest");
+const app = require("../../../app");
+const db = require("../../../db/connection");
+const seed = require("../../../db/seeds/seed");
+const testData = require("../../../db/data/test-data");
+
+beforeEach(async () => {
+  await db.query("BEGIN;"); // Start a new transaction
+  // await db.query(
+  //   `TRUNCATE TABLE comments, articles, users, topics, deletedUsers RESTART IDENTITY CASCADE;`
+  // );
+  await seed(testData);
+});
+
+afterEach(async () => {
+  await db.query("ROLLBACK;"); // Roll back transaction to reset state for next test
+});
+
+afterAll(() => db.end());
+
+describe("DELETE /api/users/:username", () => {
+  test("user deletes their account, issue appropriate response, and sets author of any comments and articles written by user to NULL", async () => {
+    const loginObj = {
+      username: "butter_bridge",
+      password: "P@ssw0rd_Br1dge!",
+    };
+
+    const loginResponse = await request(app)
+      .post("/api/users/login")
+      .send(loginObj)
+      .expect(200);
+
+    const token = loginResponse.body.token;
+
+    const deleteUserResponse = await request(app)
+      .delete("/api/users/butter_bridge")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(204);
+
+    expect(deleteUserResponse.text).toBe("");
+
+    const deletedUser = await db.query(
+      "SELECT deleted_at FROM users WHERE username = $1",
+      [loginObj.username]
+    );
+
+    expect(deletedUser.rows[0].deleted_at).not.toBeNull();
+
+    const comments = await db.query(
+      "SELECT * FROM comments WHERE author = $1",
+      [loginObj.username]
+    );
+
+    expect(comments.rowCount).toBe(0);
+
+    const articles = await db.query(
+      "SELECT * FROM articles WHERE author = $1",
+      [loginObj.username]
+    );
+
+    expect(articles.rowCount).toBe(0);
+  });
+  test("admin deletes a user account, issue appropriate response, and sets author of any comments and articles written by user to NULL", async () => {
+    const loginObj = {
+      username: process.env.ADMIN_USERNAME,
+      password: process.env.ADMIN_PASSWORD,
+    };
+
+    const loginResponse = await request(app)
+      .post("/api/users/login")
+      .send(loginObj)
+      .expect(200);
+
+    const token = loginResponse.body.token;
+
+    const deleteUserResponse = await request(app)
+      .delete("/api/users/butter_bridge")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(204);
+
+    expect(deleteUserResponse.text).toBe("");
+
+    const deletedUsername = "butter_bridge";
+
+    const deletedUser = await db.query(
+      "SELECT deleted_at FROM users WHERE username = $1",
+      [deletedUsername]
+    );
+
+    expect(deletedUser.rows[0].deleted_at).not.toBeNull();
+
+    const comments = await db.query(
+      "SELECT * FROM comments WHERE author = $1",
+      [deletedUsername]
+    );
+
+    expect(comments.rowCount).toBe(0);
+
+    const articles = await db.query(
+      "SELECT * FROM articles WHERE author = $1",
+      [deletedUsername]
+    );
+
+    expect(articles.rowCount).toBe(0);
+  });
+  test("Correct 401 response when attempting to delete user when not logged in", async () => {
+    const errorResponse = await request(app)
+      .delete("/api/users/butter_bridge")
+      .expect(401);
+
+    expect(errorResponse.body.message).toBe("No token provided");
+  });
+  test("Correct 403 response when attempting to delete user when user is already deleted", async () => {
+    const loginObj = {
+      username: "butter_bridge",
+      password: "P@ssw0rd_Br1dge!",
+    };
+
+    const loginResponse = await request(app)
+      .post("/api/users/login")
+      .send(loginObj)
+      .expect(200);
+
+    const token = loginResponse.body.token;
+
+    const deleteUserResponse = await request(app)
+      .delete("/api/users/butter_bridge")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(204);
+
+    const errorResponse = await request(app)
+      .delete("/api/users/butter_bridge")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(403);
+
+    expect(errorResponse.body.message).toBe("Account deleted");
+  });
+  test("Correct 403 response when user attempts to delete a different user's account", async () => {
+    const loginObj = {
+      username: "butter_bridge",
+      password: "P@ssw0rd_Br1dge!",
+    };
+
+    const loginResponse = await request(app)
+      .post("/api/users/login")
+      .send(loginObj)
+      .expect(200);
+
+    const token = loginResponse.body.token;
+
+    const errorResponse = await request(app)
+      .delete("/api/users/rogersop")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(403);
+
+    expect(errorResponse.body.message).toBe("Forbidden");
+  });
+});

--- a/__tests__/endpoint_tests/users/register-user.test.js
+++ b/__tests__/endpoint_tests/users/register-user.test.js
@@ -47,13 +47,28 @@ describe("POST /api/users", () => {
     const usersTable = await db.query("SELECT * FROM users");
     expect(usersTable.rows).toHaveLength(6);
   });
-  test("409 when registering with a username that belonged to an inactive user", async () => {
+  test("409 when registering with a username that belongs to an inactive user", async () => {
+    const loginObj = {
+      username: "butter_bridge",
+      password: "P@ssw0rd_Br1dge!",
+    };
+
+    const loginResponse = await request(app)
+      .post("/api/users/login")
+      .send(loginObj);
+
+    const token = loginResponse.body.token;
+
+    const deleteUserResponse = await request(app)
+      .delete("/api/users/butter_bridge")
+      .set("Authorization", `Bearer ${token}`);
+
     const registerObj = {
-      username: "banana",
-      password: "oneD0esN!tSimPly!",
-      name: "Sean",
+      username: "butter_bridge",
+      name: "jonny",
       avatar_url:
-        "https://lisasoddthoughts.com/wp-content/uploads/2021/01/lord-of-the-rings-sean-bean-boromir-1584636601-1200x675.jpg",
+        "https://www.healthytherapies.com/wp-content/uploads/2016/06/Lime3.jpg",
+      password: "P@ssw0rd_Br1dge!",
     };
 
     await request(app)

--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -1,4 +1,4 @@
-const { createUser, verifyUser } = require("../models/users.model");
+const { createUser, verifyUser, removeUser } = require("../models/users.model");
 const jwt = require("jsonwebtoken");
 
 exports.registerUser = async (req, res, next) => {
@@ -93,6 +93,16 @@ exports.loginUser = async (req, res, next) => {
       },
       token,
     });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.deleteUser = async (req, res, next) => {
+  const { username } = req.params;
+  try {
+    await removeUser(username);
+    res.status(204).send();
   } catch (error) {
     next(error);
   }

--- a/db/seeds/seed.js
+++ b/db/seeds/seed.js
@@ -14,7 +14,6 @@ const seed = async ({ topicData, userData, articleData, commentData }) => {
     await db.query(`DROP TABLE IF EXISTS articles;`);
     await db.query(`DROP TABLE IF EXISTS users;`);
     await db.query(`DROP TABLE IF EXISTS topics;`);
-    // await db.query(`DROP TABLE IF EXISTS deletedUsers;`);
 
     await db.query(`
       CREATE TABLE topics (
@@ -57,13 +56,6 @@ const seed = async ({ topicData, userData, articleData, commentData }) => {
         created_at TIMESTAMP DEFAULT NOW()
       );
     `);
-
-    // await db.query(`
-    //   CREATE TABLE deletedUsers (
-    //     username VARCHAR(20) PRIMARY KEY,
-    //     deleted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    //   );
-    // `);
 
     const hashedUserData = await hashPasswords(userData);
     const hashedAdminPassword = await hashPassword(process.env.ADMIN_PASSWORD);
@@ -131,19 +123,6 @@ const seed = async ({ topicData, userData, articleData, commentData }) => {
       )
     );
     await db.query(insertCommentsQueryStr);
-
-    // const deletedUserData = [
-    //   {
-    //     username: "banana",
-    //     deleted_at: new Date().toISOString(),
-    //   },
-    // ];
-
-    // const insertDeletedUsersQueryStr = format(
-    //   "INSERT INTO deletedUsers (username,deleted_at) VALUES %L;",
-    //   deletedUserData.map(({ username, deleted_at }) => [username, deleted_at])
-    // );
-    // await db.query(insertDeletedUsersQueryStr);
   } catch (error) {}
 };
 

--- a/db/seeds/seed.js
+++ b/db/seeds/seed.js
@@ -14,7 +14,7 @@ const seed = async ({ topicData, userData, articleData, commentData }) => {
     await db.query(`DROP TABLE IF EXISTS articles;`);
     await db.query(`DROP TABLE IF EXISTS users;`);
     await db.query(`DROP TABLE IF EXISTS topics;`);
-    await db.query(`DROP TABLE IF EXISTS deletedUsers;`);
+    // await db.query(`DROP TABLE IF EXISTS deletedUsers;`);
 
     await db.query(`
       CREATE TABLE topics (
@@ -29,7 +29,8 @@ const seed = async ({ topicData, userData, articleData, commentData }) => {
         name VARCHAR(30) NOT NULL,
         avatar_url VARCHAR,
         password VARCHAR NOT NULL,
-        role VARCHAR(10) DEFAULT 'user'
+        role VARCHAR(10) DEFAULT 'user',
+        deleted_at TIMESTAMP NULL
       );
     `);
 
@@ -38,7 +39,7 @@ const seed = async ({ topicData, userData, articleData, commentData }) => {
         article_id SERIAL PRIMARY KEY,
         title VARCHAR NOT NULL,
         topic VARCHAR NOT NULL REFERENCES topics(slug),
-        author VARCHAR NOT NULL REFERENCES users(username),
+        author VARCHAR(20),
         body VARCHAR NOT NULL,
         created_at TIMESTAMP DEFAULT NOW(),
         votes INT DEFAULT 0 NOT NULL,
@@ -51,18 +52,18 @@ const seed = async ({ topicData, userData, articleData, commentData }) => {
         comment_id SERIAL PRIMARY KEY,
         body VARCHAR NOT NULL,
         article_id INT REFERENCES articles(article_id) NOT NULL,
-        author VARCHAR REFERENCES users(username) NOT NULL,
+        author VARCHAR(20),
         votes INT DEFAULT 0 NOT NULL,
         created_at TIMESTAMP DEFAULT NOW()
       );
     `);
 
-    await db.query(`
-      CREATE TABLE deletedUsers (
-        username VARCHAR(20) PRIMARY KEY,
-        deleted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-      );
-    `);
+    // await db.query(`
+    //   CREATE TABLE deletedUsers (
+    //     username VARCHAR(20) PRIMARY KEY,
+    //     deleted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    //   );
+    // `);
 
     const hashedUserData = await hashPasswords(userData);
     const hashedAdminPassword = await hashPassword(process.env.ADMIN_PASSWORD);
@@ -131,18 +132,18 @@ const seed = async ({ topicData, userData, articleData, commentData }) => {
     );
     await db.query(insertCommentsQueryStr);
 
-    const deletedUserData = [
-      {
-        username: "banana",
-        deleted_at: new Date().toISOString(),
-      },
-    ];
+    // const deletedUserData = [
+    //   {
+    //     username: "banana",
+    //     deleted_at: new Date().toISOString(),
+    //   },
+    // ];
 
-    const insertDeletedUsersQueryStr = format(
-      "INSERT INTO deletedUsers (username,deleted_at) VALUES %L;",
-      deletedUserData.map(({ username, deleted_at }) => [username, deleted_at])
-    );
-    await db.query(insertDeletedUsersQueryStr);
+    // const insertDeletedUsersQueryStr = format(
+    //   "INSERT INTO deletedUsers (username,deleted_at) VALUES %L;",
+    //   deletedUserData.map(({ username, deleted_at }) => [username, deleted_at])
+    // );
+    // await db.query(insertDeletedUsersQueryStr);
   } catch (error) {}
 };
 

--- a/endpoints.json
+++ b/endpoints.json
@@ -62,5 +62,9 @@
       },
       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImJ1dHRlcl9icmlkZ2UiLCJyb2xlIjoidXNlciIsImlhdCI6MTY4MDY3NDA2MCwiZXhwIjoxNjgwNjc3NjYwfQ.sYpFZP0Fz8Hby8QOCZYV8PqOlgfZHMoNql0dQX6y7aQ"
     }
+  },
+  "DELETE /api/users/:username": {
+    "description": "allows the user (or an admin) to delete the user account.",
+    "queries": []
   }
 }

--- a/models/users.model.js
+++ b/models/users.model.js
@@ -3,11 +3,10 @@ const { hashPassword } = require("../utils/seedUtils");
 const bcrypt = require("bcrypt");
 
 exports.createUser = async (username, name, password, avatar_url) => {
-  const deletedUserMatch = await db.query(
-    "SELECT * FROM deletedUsers WHERE username = $1",
-    [username]
-  );
-  if (deletedUserMatch.rowCount) {
+  const userMatch = await db.query("SELECT * FROM users WHERE username = $1", [
+    username,
+  ]);
+  if (userMatch.rowCount) {
     const error = new Error("Username already taken");
     error.status = 409;
     throw error;
@@ -29,12 +28,56 @@ exports.createUser = async (username, name, password, avatar_url) => {
 };
 
 exports.verifyUser = async (username, password) => {
-  const result = await db.query("SELECT * FROM users WHERE username = $1", [
-    username,
-  ]);
+  const result = await db.query(
+    "SELECT * FROM users WHERE username = $1 AND deleted_at IS NULL",
+    [username]
+  );
   const user = result.rows[0];
   if (user && (await bcrypt.compare(password, user.password))) {
     return user;
   }
   return null;
+};
+
+exports.removeUser = async (username) => {
+  const client = await db.connect();
+
+  try {
+    // Start a transaction
+    await client.query("BEGIN");
+
+    // Update the users table
+    await client.query(
+      "UPDATE users SET deleted_at = NOW() WHERE username = $1",
+      [username]
+    );
+
+    // Update the comments table to set the author to NULL
+    await client.query("UPDATE comments SET author = NULL WHERE author = $1", [
+      username,
+    ]);
+
+    // Update the articles table to set the author to NULL
+    await client.query("UPDATE articles SET author = NULL WHERE author = $1", [
+      username,
+    ]);
+
+    // Commit the transaction
+    await client.query("COMMIT");
+  } catch (error) {
+    // Rollback the transaction in case of an error
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    // Release the client back to the pool
+    client.release();
+  }
+};
+
+exports.getUserByUsername = async (username) => {
+  const usernameQueryResult = await db.query(
+    "SELECT * FROM users WHERE username = $1 AND deleted_at IS NULL",
+    [username]
+  );
+  return usernameQueryResult.rowCount;
 };

--- a/routes/users-router.js
+++ b/routes/users-router.js
@@ -1,10 +1,23 @@
-const { registerUser, loginUser } = require("../controllers/users.controller");
-const { preventLoggedInUser } = require("../middleware/auth");
+const {
+  registerUser,
+  loginUser,
+  deleteUser,
+} = require("../controllers/users.controller");
+const {
+  preventLoggedInUser,
+  checkRole,
+  checkUser,
+  checkUserStatus,
+} = require("../middleware/auth");
 
 const usersRouter = require("express").Router();
 
 usersRouter.route("/").post(preventLoggedInUser, registerUser);
 
 usersRouter.route("/login").post(preventLoggedInUser, loginUser);
+
+usersRouter
+  .route("/:username")
+  .delete(checkUserStatus, checkRole("user"), checkUser, deleteUser);
 
 module.exports = usersRouter;


### PR DESCRIPTION
this pull request will introduce all necessary functionality to enable deletion of a user's account - include middleware, routing, controller and model functions. Seeding also changed so that users table now has a deleted_at key, so that all users (active and deleted) are in the same table, and deleting a user account sets the author of comments and articles written by the user to be NULL. Test-driven development used, with full testing of the endpoint. Endpoints.json updated